### PR TITLE
Change vite.ssrLoadModule to a plain import() when prerendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   "private": true,
   "scripts": {
     "dev": "node server",
-    "build": "yarn build:clientAssets && node prerender",
+    "build": "yarn build:clientAssets && yarn build:server && node --experimental-specifier-resolution=node prerender",
     "build:clientAssets": "vite build --outDir dist/static",
+    "build:server": "vite --config vite.config.server.js build --outDir dist/server --ssr src/entry-server.jsx",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "page": "tropical-scaffold --type=page",

--- a/prerender.js
+++ b/prerender.js
@@ -32,11 +32,8 @@ async function prerender() {
       )
     }
   } catch (e) {
-    vite.ssrFixStacktrace(e)
     console.error(e)
   }
-
-  await vite.close()
 }
 
 prerender()

--- a/prerender.js
+++ b/prerender.js
@@ -1,22 +1,14 @@
 import fse from 'fs-extra'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { createServer as createViteServer } from 'vite'
 
 const dir = dirname(fileURLToPath(import.meta.url))
 
-const transformedTemplate = fse.readFileSync(
-  resolve(dir, 'dist/static/index.html'),
-  'utf-8'
-)
+const transformedTemplate = fse.readFileSync(resolve(dir, 'dist/static/index.html'), 'utf-8')
 
-async function prerender () {
-  const vite = await createViteServer({
-    server: { middlewareMode: 'ssr' }
-  })
-
+async function prerender() {
   try {
-    const { Renderer } = await vite.ssrLoadModule('/src/entry-server.jsx')
+    const { Renderer } = await import('./dist/server/entry-server.js')
     const renderer = new Renderer(transformedTemplate)
 
     Object.entries(renderer.pages).forEach(([pathname, page]) => {
@@ -35,7 +27,9 @@ async function prerender () {
 
     const pkg = JSON.parse(await fse.readFile('./package.json'))
     if (pkg.tropical.siteHost === 'https://www.example.org') {
-      console.log(`⚠️   Configure tropical.siteHost in package.json, otherwise links in your JSON Feed won't work!`)
+      console.log(
+        `⚠️   Configure tropical.siteHost in package.json, otherwise links in your JSON Feed won't work!`
+      )
     }
   } catch (e) {
     vite.ssrFixStacktrace(e)

--- a/vite.config.server.js
+++ b/vite.config.server.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import mdx from '@mdx-js/rollup'
+import rehypeSlug from 'rehype-slug'
+
+export default defineConfig({
+  plugins: [react(), mdx({ rehypePlugins: [rehypeSlug] })],
+  build: {
+    assetsInlineLimit: 0,
+    rollupOptions: {
+      output: {
+        format: 'es'
+      }
+    }
+  }
+})


### PR DESCRIPTION
Fixes #42 

One change in 10.0.0 was to switch from a 2-step prerender (build the server bundle, then import & use it) to one (import the `Renderer` directly into the prerenderer with `vite.ssrLoadModule`)

However as raised in #42, that meant some assets were being referenced by their original name rather than the cacheable hashed name.

This change switches back to the 2-step prerender, while keeping 10.0.0's switch to ES Modules at the project level.