### PR TITLE
Support npm & pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ This is a [template repo](https://docs.github.com/en/github/creating-cloning-and
 
 Welcome to your new [Tropical](https://tropical.js.org/) site!
 
-Install dependencies with `yarn`, then...
+Using your choice of `npm`, `yarn` or `pnpm`, install dependencies then (using `yarn` as an example)...
 
 - **`yarn dev`** starts a dev server at [localhost:3000](http://localhost:3000/)
 - **`yarn build`** builds the static site into `dist/static`
 - **`yarn stories`** starts [Ladle](https://ladle.dev/)
 - **`yarn page my-new-page`** scaffolds a file for a new page
 - **`yarn component MyNewComponent`** scaffolds files for a new component
-
-(`npm` equivalients to `yarn` commands should work too)
 
 Check out [the docs](https://tropical.js.org) or dive in and explore the `src` directory.
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "private": true,
   "scripts": {
     "dev": "node server",
-    "build": "yarpm build:clientAssets && yarpm build:server && node --experimental-specifier-resolution=node prerender",
+    "build": "yarpm run build:clientAssets && yarpm run build:server && node --experimental-specifier-resolution=node prerender",
     "build:clientAssets": "vite --config vite.config.client.js build --outDir dist/static",
     "build:server": "vite --config vite.config.server.js build --outDir dist/server --ssr src/entry-server.jsx",
     "stories": "ladle serve -p 6006",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "rollup": "^2.77.2",
     "tropical-islands": "^2.0.0",
     "tropical-scaffold": "^2.0.0",
-    "vite": "^3.0.4"
+    "vite": "^3.0.4",
+    "yarpm": "^1.1.1"
   },
   "engines": {
     "node": ">=16"
@@ -31,7 +32,7 @@
   "private": true,
   "scripts": {
     "dev": "node server",
-    "build": "yarn build:clientAssets && yarn build:server && node --experimental-specifier-resolution=node prerender",
+    "build": "yarpm build:clientAssets && yarpm build:server && node --experimental-specifier-resolution=node prerender",
     "build:clientAssets": "vite --config vite.config.client.js build --outDir dist/static",
     "build:server": "vite --config vite.config.server.js build --outDir dist/server --ssr src/entry-server.jsx",
     "stories": "ladle serve -p 6006",

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -13,6 +13,8 @@ export const meta = {
 - **`yarn page my-new-page`** scaffolds a file for a new page
 - **`yarn component MyNewComponent`** scaffolds files for a new component
 
+You can also use `npm` or `pnpm` instead of `yarn`.
+
 ## Pages
 
 This is your homepage. Pages live in `src/pages` and are either `.mdx` files (like this one) or plain old React components in `.jsx` files (like the [404](/404/) example).


### PR DESCRIPTION
I always said you could use npm instead of yarn, but that wasn't really true with `yarn` hardcoded into package scripts.

This makes it possible to run package scripts with any of yarn, pnpm or npm, using [yarpm](https://github.com/BendingBender/yarpm) within package scripts.